### PR TITLE
fix: keep system prompt #17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-04-09
+
+### Added
+
+- **`keep_head` parameter on `SlidingWindowProcessor`** — preserve N messages from the start of the conversation during sliding window trimming. Prevents loss of system prompts and initial instructions when the window slides forward. Supports all `ContextSize` formats: `("messages", N)`, `("tokens", N)`, `("fraction", F)`. Automatically adjusts the head boundary to avoid splitting tool call/response pairs. ([#17](https://github.com/vstorm-co/summarization-pydantic-ai/issues/17), reported by [@zlowred](https://github.com/zlowred))
+
+  ```python
+  # Keep system prompt when trimming
+  processor = SlidingWindowProcessor(
+      trigger=("messages", 100),
+      keep=("messages", 50),
+      keep_head=("messages", 1),
+  )
+  ```
+
+- **`keep_head` on `SlidingWindowCapability`** — same parameter exposed on the capability wrapper
+- **`keep_head` on `create_sliding_window_processor()`** — same parameter on the factory function
+
 ## [0.1.3] - 2026-04-02
 
 ### Added
@@ -211,6 +229,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Requires `pydantic-ai>=0.1.0`
 - Optional `tiktoken` support for accurate token counting
 
+[0.1.4]: https://github.com/vstorm-co/summarization-pydantic-ai/releases/tag/v0.1.4
+[0.1.3]: https://github.com/vstorm-co/summarization-pydantic-ai/releases/tag/v0.1.3
+[0.1.2]: https://github.com/vstorm-co/summarization-pydantic-ai/releases/tag/v0.1.2
+[0.1.1]: https://github.com/vstorm-co/summarization-pydantic-ai/releases/tag/v0.1.1
+[0.1.0]: https://github.com/vstorm-co/summarization-pydantic-ai/releases/tag/v0.1.0
+[0.0.5]: https://github.com/vstorm-co/summarization-pydantic-ai/releases/tag/v0.0.5
 [0.0.4]: https://github.com/vstorm-co/summarization-pydantic-ai/releases/tag/v0.0.4
 [0.0.3]: https://github.com/vstorm-co/summarization-pydantic-ai/releases/tag/v0.0.3
 [0.0.2]: https://github.com/vstorm-co/summarization-pydantic-ai/releases/tag/v0.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "summarization-pydantic-ai"
-version = "0.1.3"
+version = "0.1.4"
 description = "Automatic Conversation Summarization and History Management for Pydantic AI"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_summarization/capability.py
+++ b/src/pydantic_ai_summarization/capability.py
@@ -141,6 +141,7 @@ class SlidingWindowCapability(AbstractCapability[Any]):
             capabilities=[SlidingWindowCapability(
                 trigger=("messages", 100),
                 keep=("messages", 50),
+                keep_head=("messages", 1),  # preserve system prompt
             )],
         )
         ```
@@ -148,6 +149,7 @@ class SlidingWindowCapability(AbstractCapability[Any]):
 
     trigger: ContextSize = ("messages", 100)
     keep: ContextSize = ("messages", 50)
+    keep_head: ContextSize | None = None
     token_counter: TokenCounter = field(default=count_tokens_approximately)
     _processor: SlidingWindowProcessor | None = field(default=None, init=False, repr=False)
 
@@ -159,6 +161,7 @@ class SlidingWindowCapability(AbstractCapability[Any]):
         self._processor = SlidingWindowProcessor(
             trigger=self.trigger,
             keep=self.keep,
+            keep_head=self.keep_head,
             token_counter=self.token_counter,
         )
 

--- a/src/pydantic_ai_summarization/sliding_window.py
+++ b/src/pydantic_ai_summarization/sliding_window.py
@@ -54,6 +54,7 @@ class SlidingWindowProcessor:
     Attributes:
         trigger: Threshold(s) that trigger window trimming.
         keep: How many messages to keep after trimming.
+        keep_head: How many messages to keep from the start of the conversation.
         token_counter: Function to count tokens (only used for token-based triggers/keep).
         max_input_tokens: Maximum input tokens (required for fraction-based config).
 
@@ -62,10 +63,12 @@ class SlidingWindowProcessor:
         from pydantic_ai import Agent
         from pydantic_ai_summarization import SlidingWindowProcessor
 
-        # Keep last 50 messages, trim when reaching 100
+        # Keep last 50 messages, trim when reaching 100,
+        # always preserve the system prompt
         processor = SlidingWindowProcessor(
             trigger=("messages", 100),
             keep=("messages", 50),
+            keep_head=("messages", 1),
         )
 
         agent = Agent(
@@ -86,12 +89,24 @@ class SlidingWindowProcessor:
     """
 
     keep: ContextSize = ("messages", _DEFAULT_WINDOW_SIZE)
-    """How many messages to keep after trimming.
+    """How many messages to keep after trimming (from the tail).
 
     Examples:
         - ("messages", 50) - keep last 50 messages
         - ("tokens", 10000) - keep last 10k tokens worth
         - ("fraction", 0.3) - keep last 30% of max_input_tokens
+    """
+
+    keep_head: ContextSize | None = None
+    """How many messages to keep from the start of the conversation.
+
+    This is useful for preserving system prompts or initial instructions
+    that should always remain in context regardless of trimming.
+
+    Examples:
+        - ("messages", 1) - keep the first message (typically the system prompt)
+        - ("messages", 3) - keep the first 3 messages
+        - ("tokens", 5000) - keep head messages up to ~5000 tokens
     """
 
     token_counter: TokenCounter = field(default=count_tokens_approximately)
@@ -107,6 +122,12 @@ class SlidingWindowProcessor:
         self._trigger_conditions, self.keep = _validate_trig_keep(
             self.trigger, self.keep, self.max_input_tokens
         )
+        if self.keep_head is not None:
+            self.keep_head = _validate_ctx(self.keep_head, "keep_head")
+            if self.keep_head[0] == "fraction" and self.max_input_tokens is None:
+                raise ValueError(
+                    "max_input_tokens is required when using fraction-based keep_head."
+                )
 
     def _validate_context_size(self, context: ContextSize, parameter_name: str) -> ContextSize:
         """Validate context configuration tuples."""
@@ -142,6 +163,40 @@ class SlidingWindowProcessor:
         """Check if cutting at index would separate tool call/response pairs."""
         return _is_safe(messages, cutoff_index)
 
+    def _determine_head_count(self, messages: list[ModelMessage]) -> int:
+        """Determine how many messages to keep from the head of the conversation.
+
+        Returns 0 if keep_head is not configured.
+        Adjusts the count upward if needed to avoid splitting tool call/response pairs.
+        """
+        if self.keep_head is None:
+            return 0
+
+        kind, value = self.keep_head
+
+        if kind == "messages":
+            raw_count = min(int(value), len(messages))
+        elif kind == "tokens":
+            raw_count = self._find_head_token_count(messages, int(value))
+        elif kind == "fraction" and self.max_input_tokens:
+            target = int(self.max_input_tokens * value)
+            raw_count = self._find_head_token_count(messages, target)
+        else:
+            return 0
+
+        # Adjust upward to avoid splitting tool call/response pairs
+        while raw_count < len(messages) and not _is_safe(messages, raw_count):
+            raw_count += 1
+
+        return raw_count
+
+    def _find_head_token_count(self, messages: list[ModelMessage], target_tokens: int) -> int:
+        """Find how many messages from the head fit within the target token budget."""
+        for i in range(1, len(messages) + 1):
+            if cast(int, self.token_counter(messages[:i])) > target_tokens:
+                return max(0, i - 1)
+        return len(messages)
+
     async def __call__(self, messages: list[ModelMessage]) -> list[ModelMessage]:
         """Process messages and trim if needed.
 
@@ -163,6 +218,15 @@ class SlidingWindowProcessor:
         if cutoff_index <= 0:
             return messages
 
+        head_count = self._determine_head_count(messages)
+
+        if head_count > 0:
+            # Ensure cutoff doesn't overlap with head messages
+            effective_cutoff = max(cutoff_index, head_count)
+            if effective_cutoff >= len(messages):
+                return messages
+            return messages[:head_count] + messages[effective_cutoff:]
+
         # Simply discard old messages and keep recent ones
         return messages[cutoff_index:]
 
@@ -170,6 +234,7 @@ class SlidingWindowProcessor:
 def create_sliding_window_processor(
     trigger: ContextSize | list[ContextSize] | None = ("messages", _DEFAULT_TRIGGER_MESSAGES),
     keep: ContextSize = ("messages", _DEFAULT_WINDOW_SIZE),
+    keep_head: ContextSize | None = None,
     max_input_tokens: int | None = None,
     token_counter: TokenCounter | None = None,
 ) -> SlidingWindowProcessor:
@@ -185,7 +250,11 @@ def create_sliding_window_processor(
             - ("fraction", F) - trigger at F fraction of max_input_tokens
             - List of tuples to trigger on any condition
             Defaults to ("messages", 100).
-        keep: How many messages to keep after trimming. Defaults to ("messages", 50).
+        keep: How many messages to keep after trimming (from the tail).
+            Defaults to ("messages", 50).
+        keep_head: How many messages to keep from the start of the conversation.
+            Useful for preserving system prompts. Defaults to None (no head
+            preservation).
         max_input_tokens: Maximum input tokens (required for fraction-based triggers).
         token_counter: Custom token counting function. Defaults to approximate counter.
 
@@ -197,10 +266,11 @@ def create_sliding_window_processor(
         from pydantic_ai import Agent
         from pydantic_ai_summarization import create_sliding_window_processor
 
-        # Simple: keep last 30 messages when reaching 60
+        # Keep last 30 messages when reaching 60, preserve system prompt
         processor = create_sliding_window_processor(
             trigger=("messages", 60),
             keep=("messages", 30),
+            keep_head=("messages", 1),
         )
 
         # Token-based: keep ~50k tokens when reaching 100k
@@ -219,6 +289,9 @@ def create_sliding_window_processor(
         "trigger": trigger,
         "keep": keep,
     }
+
+    if keep_head is not None:
+        kwargs["keep_head"] = keep_head
 
     if max_input_tokens is not None:
         kwargs["max_input_tokens"] = max_input_tokens

--- a/src/pydantic_ai_summarization/sliding_window.py
+++ b/src/pydantic_ai_summarization/sliding_window.py
@@ -182,7 +182,7 @@ class SlidingWindowProcessor:
             target = int(self.max_input_tokens * value)
             raw_count = self._find_head_token_count(messages, target)
         else:
-            return 0
+            return 0  # pragma: no cover
 
         # Adjust upward to avoid splitting tool call/response pairs
         while raw_count < len(messages) and not _is_safe(messages, raw_count):

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -542,9 +542,7 @@ class TestKeepHead:
         )
         messages: list[ModelMessage] = [
             ModelRequest(parts=[UserPromptPart(content="Initial question")]),
-            ModelResponse(
-                parts=[ToolCallPart(tool_name="search", args={}, tool_call_id="call_1")]
-            ),
+            ModelResponse(parts=[ToolCallPart(tool_name="search", args={}, tool_call_id="call_1")]),
             # keep_head=2 would cut here — but call_1 (index 1) is before, return (index 2) after
             ModelRequest(
                 parts=[ToolReturnPart(tool_name="search", content="Result", tool_call_id="call_1")]

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -392,3 +392,210 @@ class TestSlidingWindowProcessor:
         processor = SlidingWindowProcessor()
         result = processor._validate_context_size(("tokens", 500), "test")
         assert result == ("tokens", 500)
+
+
+class TestKeepHead:
+    """Tests for the keep_head parameter."""
+
+    def test_keep_head_default_is_none(self):
+        """Test that keep_head defaults to None."""
+        processor = SlidingWindowProcessor()
+        assert processor.keep_head is None
+
+    def test_keep_head_messages_config(self):
+        """Test configuring keep_head with message count."""
+        processor = SlidingWindowProcessor(keep_head=("messages", 2))
+        assert processor.keep_head == ("messages", 2)
+
+    def test_keep_head_tokens_config(self):
+        """Test configuring keep_head with token count."""
+        processor = SlidingWindowProcessor(keep_head=("tokens", 500))
+        assert processor.keep_head == ("tokens", 500)
+
+    def test_keep_head_fraction_requires_max_tokens(self):
+        """Test that fraction-based keep_head requires max_input_tokens."""
+        with pytest.raises(ValueError, match="max_input_tokens is required"):
+            SlidingWindowProcessor(keep_head=("fraction", 0.1))
+
+    def test_keep_head_fraction_with_max_tokens(self):
+        """Test fraction-based keep_head with max_input_tokens provided."""
+        processor = SlidingWindowProcessor(
+            keep_head=("fraction", 0.1),
+            max_input_tokens=100000,
+        )
+        assert processor.keep_head == ("fraction", 0.1)
+
+    def test_keep_head_invalid_negative(self):
+        """Test that negative keep_head is rejected."""
+        with pytest.raises(ValueError, match="non-negative"):
+            SlidingWindowProcessor(keep_head=("messages", -1))
+
+    def test_keep_head_invalid_fraction(self):
+        """Test that invalid fraction for keep_head is rejected."""
+        with pytest.raises(ValueError, match="between 0 and 1"):
+            SlidingWindowProcessor(
+                keep_head=("fraction", 1.5),
+                max_input_tokens=100000,
+            )
+
+    @pytest.mark.anyio
+    async def test_keep_head_preserves_system_prompt(self):
+        """Test that keep_head=1 preserves the first message (system prompt)."""
+        from pydantic_ai.messages import SystemPromptPart
+
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 5),
+            keep=("messages", 2),
+            keep_head=("messages", 1),
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[SystemPromptPart(content="You are a helpful assistant")]),
+            *[ModelRequest(parts=[UserPromptPart(content=f"Message {i}")]) for i in range(9)],
+        ]
+        result = await processor(messages)
+        # Should have: 1 head + 2 tail = 3 messages
+        assert len(result) == 3
+        # First message should be the system prompt
+        assert isinstance(result[0], ModelRequest)
+        assert any(
+            isinstance(p, SystemPromptPart) and "helpful assistant" in p.content
+            for p in result[0].parts
+        )
+        # Last 2 should be the tail messages
+        assert result[1:] == messages[-2:]
+
+    @pytest.mark.anyio
+    async def test_keep_head_multiple_messages(self):
+        """Test keeping multiple head messages."""
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 5),
+            keep=("messages", 2),
+            keep_head=("messages", 3),
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content=f"Message {i}")]) for i in range(10)
+        ]
+        result = await processor(messages)
+        # Should have: 3 head + 2 tail = 5 messages
+        assert len(result) == 5
+        assert result[:3] == messages[:3]
+        assert result[3:] == messages[-2:]
+
+    @pytest.mark.anyio
+    async def test_keep_head_no_trimming_needed(self):
+        """Test that keep_head doesn't affect behavior when no trimming is needed."""
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 100),
+            keep=("messages", 50),
+            keep_head=("messages", 1),
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content=f"Message {i}")]) for i in range(5)
+        ]
+        result = await processor(messages)
+        assert result == messages
+
+    @pytest.mark.anyio
+    async def test_keep_head_overlap_with_tail(self):
+        """Test behavior when head and tail regions overlap (too few messages to discard)."""
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 5),
+            keep=("messages", 4),
+            keep_head=("messages", 3),
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content=f"Message {i}")]) for i in range(6)
+        ]
+        result = await processor(messages)
+        # head=3 + tail covers most messages, effective_cutoff = max(cutoff, 3)
+        # cutoff for keep=4 from 6 messages = 2, so effective_cutoff = 3
+        # Result: messages[:3] + messages[3:] = all messages
+        assert result == messages
+
+    @pytest.mark.anyio
+    async def test_keep_head_with_token_based(self):
+        """Test keep_head with token-based configuration."""
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 5),
+            keep=("messages", 2),
+            keep_head=("tokens", 100),  # ~400 chars = 100 tokens
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content="x" * 200)]),  # 50 tokens
+            ModelRequest(parts=[UserPromptPart(content="y" * 200)]),  # 50 tokens
+            ModelRequest(parts=[UserPromptPart(content="z" * 200)]),  # 50 tokens - would exceed
+            *[ModelRequest(parts=[UserPromptPart(content=f"msg {i}")]) for i in range(7)],
+        ]
+        result = await processor(messages)
+        # Should keep first 2 messages (100 tokens) and last 2
+        assert len(result) == 4
+        assert result[:2] == messages[:2]
+        assert result[2:] == messages[-2:]
+
+    @pytest.mark.anyio
+    async def test_keep_head_preserves_tool_pairs_at_boundary(self):
+        """Test that keep_head adjusts upward to avoid splitting tool pairs."""
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 5),
+            keep=("messages", 1),
+            keep_head=("messages", 1),
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content="Initial question")]),
+            ModelResponse(parts=[ToolCallPart(tool_name="search", args={}, tool_call_id="call_1")]),
+            ModelRequest(
+                parts=[ToolReturnPart(tool_name="search", content="Result", tool_call_id="call_1")]
+            ),
+            ModelResponse(parts=[TextPart(content="Answer based on search")]),
+            ModelRequest(parts=[UserPromptPart(content="Follow up 1")]),
+            ModelResponse(parts=[TextPart(content="Response 1")]),
+            ModelRequest(parts=[UserPromptPart(content="Follow up 2")]),
+        ]
+        result = await processor(messages)
+        # keep_head=1 but cutting at index 1 would split tool pair (call_1),
+        # so head should expand to include the full tool pair (3 messages)
+        head = result[: len(result) - 1]
+        # The head should not split a tool call from its return
+        tool_call_ids_in_head = set()
+        for msg in head:
+            if isinstance(msg, ModelResponse):
+                for part in msg.parts:
+                    if isinstance(part, ToolCallPart) and part.tool_call_id:
+                        tool_call_ids_in_head.add(part.tool_call_id)
+        for msg in head:
+            if isinstance(msg, ModelRequest):
+                for part in msg.parts:
+                    if isinstance(part, ToolReturnPart) and part.tool_call_id:
+                        # If we have the call, we must have the return
+                        if part.tool_call_id in tool_call_ids_in_head:
+                            assert True  # Return is in head with its call
+
+    @pytest.mark.anyio
+    async def test_keep_head_zero_messages(self):
+        """Test keep_head with zero messages (same as None)."""
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 5),
+            keep=("messages", 3),
+            keep_head=("messages", 0),
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content=f"Message {i}")]) for i in range(10)
+        ]
+        result = await processor(messages)
+        # keep_head=0 means no head preserved, should behave like keep_head=None
+        assert len(result) == 3
+        assert result == messages[-3:]
+
+    def test_factory_with_keep_head(self):
+        """Test create_sliding_window_processor with keep_head."""
+        processor = create_sliding_window_processor(
+            trigger=("messages", 60),
+            keep=("messages", 30),
+            keep_head=("messages", 1),
+        )
+        assert processor.keep_head == ("messages", 1)
+
+    def test_factory_without_keep_head(self):
+        """Test create_sliding_window_processor without keep_head (default None)."""
+        processor = create_sliding_window_processor()
+        assert processor.keep_head is None

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -538,11 +538,14 @@ class TestKeepHead:
         processor = SlidingWindowProcessor(
             trigger=("messages", 5),
             keep=("messages", 1),
-            keep_head=("messages", 1),
+            keep_head=("messages", 2),  # Would cut at index 2, splitting call_1
         )
         messages: list[ModelMessage] = [
             ModelRequest(parts=[UserPromptPart(content="Initial question")]),
-            ModelResponse(parts=[ToolCallPart(tool_name="search", args={}, tool_call_id="call_1")]),
+            ModelResponse(
+                parts=[ToolCallPart(tool_name="search", args={}, tool_call_id="call_1")]
+            ),
+            # keep_head=2 would cut here — but call_1 (index 1) is before, return (index 2) after
             ModelRequest(
                 parts=[ToolReturnPart(tool_name="search", content="Result", tool_call_id="call_1")]
             ),
@@ -552,23 +555,11 @@ class TestKeepHead:
             ModelRequest(parts=[UserPromptPart(content="Follow up 2")]),
         ]
         result = await processor(messages)
-        # keep_head=1 but cutting at index 1 would split tool pair (call_1),
-        # so head should expand to include the full tool pair (3 messages)
-        head = result[: len(result) - 1]
-        # The head should not split a tool call from its return
-        tool_call_ids_in_head = set()
-        for msg in head:
-            if isinstance(msg, ModelResponse):
-                for part in msg.parts:
-                    if isinstance(part, ToolCallPart) and part.tool_call_id:
-                        tool_call_ids_in_head.add(part.tool_call_id)
-        for msg in head:
-            if isinstance(msg, ModelRequest):
-                for part in msg.parts:
-                    if isinstance(part, ToolReturnPart) and part.tool_call_id:
-                        # If we have the call, we must have the return
-                        if part.tool_call_id in tool_call_ids_in_head:
-                            assert True  # Return is in head with its call
+        # Cutting at index 2 is unsafe (splits call_1 pair), so head expands to 3
+        # Result: head (3 messages) + tail (1 message) = 4
+        assert len(result) == 4
+        assert result[:3] == messages[:3]
+        assert result[3] == messages[-1]
 
     @pytest.mark.anyio
     async def test_keep_head_zero_messages(self):
@@ -599,3 +590,55 @@ class TestKeepHead:
         """Test create_sliding_window_processor without keep_head (default None)."""
         processor = create_sliding_window_processor()
         assert processor.keep_head is None
+
+    @pytest.mark.anyio
+    async def test_keep_head_fraction_based(self):
+        """Test keep_head with fraction-based configuration."""
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 5),
+            keep=("messages", 2),
+            keep_head=("fraction", 0.5),
+            max_input_tokens=200,  # 50% = 100 tokens budget for head
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content="x" * 200)]),  # 50 tokens
+            ModelRequest(parts=[UserPromptPart(content="y" * 200)]),  # 50 tokens -> 100 total
+            ModelRequest(parts=[UserPromptPart(content="z" * 200)]),  # would exceed 100
+            *[ModelRequest(parts=[UserPromptPart(content=f"msg {i}")]) for i in range(7)],
+        ]
+        result = await processor(messages)
+        # Should keep first 2 messages (~100 tokens) + last 2
+        assert len(result) == 4
+        assert result[:2] == messages[:2]
+        assert result[2:] == messages[-2:]
+
+    @pytest.mark.anyio
+    async def test_keep_head_token_all_fit(self):
+        """Test keep_head with token budget larger than all messages."""
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 5),
+            keep=("messages", 2),
+            keep_head=("tokens", 999999),  # Huge budget — all messages fit
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content=f"Message {i}")]) for i in range(6)
+        ]
+        result = await processor(messages)
+        # head covers all messages, effective_cutoff >= len(messages) → return as-is
+        assert result == messages
+
+    @pytest.mark.anyio
+    async def test_keep_head_covers_everything(self):
+        """Test when keep_head messages + tail overlap covers entire history."""
+        processor = SlidingWindowProcessor(
+            trigger=("messages", 5),
+            keep=("messages", 2),
+            keep_head=("messages", 5),  # Keep 5 from head of 6 total
+        )
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content=f"Message {i}")]) for i in range(6)
+        ]
+        result = await processor(messages)
+        # head=5, cutoff for keep=2 from 6 = 4, effective_cutoff = max(4, 5) = 5
+        # tail = messages[5:] = 1 message, head = 5 messages → 6 total = all messages
+        assert result == messages

--- a/uv.lock
+++ b/uv.lock
@@ -1430,7 +1430,7 @@ wheels = [
 
 [[package]]
 name = "summarization-pydantic-ai"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-ai-slim" },


### PR DESCRIPTION
## [0.1.4] - 2026-04-09

### Added

- **`keep_head` parameter on `SlidingWindowProcessor`** — preserve N messages from the start of the conversation during sliding window trimming. Prevents loss of system prompts and initial instructions when the window slides forward. Supports all `ContextSize` formats: `("messages", N)`, `("tokens", N)`, `("fraction", F)`. Automatically adjusts the head boundary to avoid splitting tool call/response pairs. ([#17](https://github.com/vstorm-co/summarization-pydantic-ai/issues/17), reported by [@zlowred](https://github.com/zlowred))

  ```python
  # Keep system prompt when trimming
  processor = SlidingWindowProcessor(
      trigger=("messages", 100),
      keep=("messages", 50),
      keep_head=("messages", 1),
  )
  ```

- **`keep_head` on `SlidingWindowCapability`** — same parameter exposed on the capability wrapper
- **`keep_head` on `create_sliding_window_processor()`** — same parameter on the factory function
