### PR TITLE
chore: release 0.1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python
         run: uv python install 3.12
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python
         run: uv python install 3.12
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.14"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync --all-extras
       - run: uv run python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v8
       - run: uv sync --all-extras
       - run: uv run python -m build
       - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`renovate.json`** ([#19](https://github.com/vstorm-co/summarization-pydantic-ai/pull/19)) — Renovate config landed; first auto-PRs (#20, #21) already merged.
 - **CI: bump `docs.yml` Python to `3.14`** ([#20](https://github.com/vstorm-co/summarization-pydantic-ai/pull/20), Renovate auto-PR).
 - **CI: bump `actions/checkout` to `v6`** across `ci.yml`, `docs.yml`, `publish.yml` ([#21](https://github.com/vstorm-co/summarization-pydantic-ai/pull/21), Renovate auto-PR).
+- **CI: bump `astral-sh/setup-uv` to `v8`** across `ci.yml` (×3) and `publish.yml` — pulled in from Renovate's [Dependency Dashboard #22](https://github.com/vstorm-co/summarization-pydantic-ai/issues/22) (rate-limited there) and folded into this release.
+- **CI: bump `actions/setup-python` to `v6`** in `docs.yml` — same source as above.
 
 No source-code changes — pure CI / dependency-bot housekeeping. Library behaviour unchanged from 0.1.4.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-05-24
+
+### Infrastructure
+
+- **`renovate.json`** ([#19](https://github.com/vstorm-co/summarization-pydantic-ai/pull/19)) — Renovate config landed; first auto-PRs (#20, #21) already merged.
+- **CI: bump `docs.yml` Python to `3.14`** ([#20](https://github.com/vstorm-co/summarization-pydantic-ai/pull/20), Renovate auto-PR).
+- **CI: bump `actions/checkout` to `v6`** across `ci.yml`, `docs.yml`, `publish.yml` ([#21](https://github.com/vstorm-co/summarization-pydantic-ai/pull/21), Renovate auto-PR).
+
+No source-code changes — pure CI / dependency-bot housekeeping. Library behaviour unchanged from 0.1.4.
+
 ## [0.1.4] - 2026-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`renovate.json`** ([#19](https://github.com/vstorm-co/summarization-pydantic-ai/pull/19)) — Renovate config landed; first auto-PRs (#20, #21) already merged.
 - **CI: bump `docs.yml` Python to `3.14`** ([#20](https://github.com/vstorm-co/summarization-pydantic-ai/pull/20), Renovate auto-PR).
 - **CI: bump `actions/checkout` to `v6`** across `ci.yml`, `docs.yml`, `publish.yml` ([#21](https://github.com/vstorm-co/summarization-pydantic-ai/pull/21), Renovate auto-PR).
-- **CI: bump `astral-sh/setup-uv` to `v8`** across `ci.yml` (×3) and `publish.yml` — pulled in from Renovate's [Dependency Dashboard #22](https://github.com/vstorm-co/summarization-pydantic-ai/issues/22) (rate-limited there) and folded into this release.
+- **CI: bump `astral-sh/setup-uv` to `v8.1.0`** across `ci.yml` (×3) and `publish.yml` — pulled in from Renovate's [Dependency Dashboard #22](https://github.com/vstorm-co/summarization-pydantic-ai/issues/22) (rate-limited there) and folded into this release. (Pinned to the specific patch because `astral-sh/setup-uv` does not maintain a rolling `v8` tag — only the `v7` and earlier majors do.)
 - **CI: bump `actions/setup-python` to `v6`** in `docs.yml` — same source as above.
 
 No source-code changes — pure CI / dependency-bot housekeeping. Library behaviour unchanged from 0.1.4.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "summarization-pydantic-ai"
-version = "0.1.4"
+version = "0.1.5"
 description = "Automatic Conversation Summarization and History Management for Pydantic AI"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Cuts the **0.1.5** release. Pure CI / dependency-bot housekeeping — no source-code changes since 0.1.4.

| PR | What |
|---|---|
| #19 | `renovate.json` config landed |
| #20 | CI: `docs.yml` Python → `3.14` (Renovate auto-PR) |
| #21 | CI: `actions/checkout` → `v6` across `ci.yml`, `docs.yml`, `publish.yml` (Renovate auto-PR) |

Library behaviour is unchanged from 0.1.4.

## Gate

- `make test` (or `uv run pytest`) — **225 passed**, 100% coverage
- `ruff format --check` + `ruff check` — clean
- `pyright` — 0 errors

## After merge

`uv build && uv publish` to ship 0.1.5 on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)