### PR TITLE
fix: async token_counter works end-to-end through compress/cutoff path (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-06-04
+
+### Fixed
+
+- **Async `token_counter` now works end-to-end through the compression/cutoff path** ([#28](https://github.com/vstorm-co/summarization-pydantic-ai/issues/28)). Async support added in [#7](https://github.com/vstorm-co/summarization-pydantic-ai/pull/7) only covered the gating check; once compression actually ran, `SummarizationProcessor.__call__` still called the counter synchronously — both for the trigger total and inside the binary-search cutoff — so an async counter (e.g. a provider `count_tokens` API for accurate PDF/image counting) crashed with `TypeError: '>=' not supported between instances of 'coroutine' and 'int'` and a `RuntimeWarning: coroutine '...' was never awaited`. `__call__` now routes both invocations through `async_count_tokens` / `async_determine_cutoff_index`, so async counters work all the way through summarization. The synchronous helpers are unchanged for sync counters.
+
 ## [0.1.6] - 2026-05-24
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "summarization-pydantic-ai"
-version = "0.1.6"
+version = "0.1.7"
 description = "Automatic Conversation Summarization and History Management for Pydantic AI"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_summarization/processor.py
+++ b/src/pydantic_ai_summarization/processor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from pydantic_ai import Agent
 from pydantic_ai.messages import (
@@ -19,6 +19,12 @@ from pydantic_ai.messages import (
     UserPromptPart,
 )
 
+from pydantic_ai_summarization._cutoff import (
+    async_count_tokens as _async_count_tokens,
+)
+from pydantic_ai_summarization._cutoff import (
+    async_determine_cutoff_index as _async_determine_cutoff,
+)
 from pydantic_ai_summarization._cutoff import (
     determine_cutoff_index as _determine_cutoff,
 )
@@ -395,12 +401,18 @@ class SummarizationProcessor:
         Returns:
             Processed message history, potentially with older messages summarized.
         """
-        total_tokens = cast(int, self.token_counter(messages))
+        total_tokens = await _async_count_tokens(self.token_counter, messages)
 
         if not self._should_summarize(messages, total_tokens):
             return messages
 
-        cutoff_index = self._determine_cutoff_index(messages)
+        cutoff_index = await _async_determine_cutoff(
+            messages,
+            self.keep,
+            self.token_counter,
+            self.max_input_tokens,
+            _DEFAULT_MESSAGES_TO_KEEP,
+        )
 
         if cutoff_index <= 0:
             return messages

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -571,3 +571,82 @@ class TestSummarizationCallPath:
                 if isinstance(content, str):
                     assert "secret connection string" not in content
                     assert "Error generating summary" not in content
+
+
+class TestAsyncTokenCounterCallPath:
+    """Async ``token_counter`` must work end-to-end through the compress path.
+
+    Regression tests for https://github.com/vstorm-co/summarization-pydantic-ai/issues/28
+    where the gating check awaited the counter but the compression/cutoff path
+    called it synchronously, crashing with a coroutine ``TypeError``.
+    """
+
+    @pytest.mark.anyio
+    async def test_call_async_counter_triggers_summarization(self):
+        """An async counter drives both the trigger check and summarization."""
+        calls = 0
+
+        async def async_counter(messages: list[ModelMessage]) -> int:
+            nonlocal calls
+            calls += 1
+            return 999_999
+
+        processor = SummarizationProcessor(
+            model="openai:gpt-4.1",
+            trigger=("tokens", 100),
+            keep=("messages", 4),
+            token_counter=async_counter,
+        )
+        processor._summarization_agent = Agent(
+            FunctionModel(lambda m, i: _MR(parts=[TextPart(content="SUMMARY")]))
+        )
+
+        messages = _build_summarizable_messages()
+        result = await processor(messages)
+
+        assert calls >= 1
+        assert len(result) < len(messages)
+        assert isinstance(result[0], ModelRequest)
+
+    @pytest.mark.anyio
+    async def test_call_async_counter_token_keep(self):
+        """An async counter is awaited inside the token-based binary-search cutoff."""
+
+        async def async_counter(messages: list[ModelMessage]) -> int:
+            return len(messages) * 10
+
+        processor = SummarizationProcessor(
+            model="openai:gpt-4.1",
+            trigger=("tokens", 10),
+            keep=("tokens", 30),
+            token_counter=async_counter,
+        )
+        processor._summarization_agent = Agent(
+            FunctionModel(lambda m, i: _MR(parts=[TextPart(content="SUMMARY")]))
+        )
+
+        messages = _build_summarizable_messages()
+        result = await processor(messages)
+
+        # Summary message plus a small preserved tail (~3 messages worth of tokens).
+        assert len(result) < len(messages)
+        assert isinstance(result[0], ModelRequest)
+
+    @pytest.mark.anyio
+    async def test_call_async_counter_below_trigger(self):
+        """An async counter under the trigger returns history unchanged."""
+
+        async def async_counter(messages: list[ModelMessage]) -> int:
+            return 5
+
+        processor = SummarizationProcessor(
+            model="openai:gpt-4.1",
+            trigger=("tokens", 100),
+            keep=("messages", 4),
+            token_counter=async_counter,
+        )
+
+        messages = _build_summarizable_messages()
+        result = await processor(messages)
+
+        assert result == messages


### PR DESCRIPTION
## Summary

Fixes #28.

Async `token_counter` support ([#7](https://github.com/vstorm-co/summarization-pydantic-ai/pull/7)) only covered the **gating** check (deciding *whether* to compress). Once compression actually ran, `SummarizationProcessor.__call__` still called the counter **synchronously** in two places:

- the trigger total (`total_tokens = cast(int, self.token_counter(messages))`)
- the binary-search cutoff (`determine_cutoff_index` → `find_token_based_cutoff`)

So an async counter — e.g. one backed by a provider's `count_tokens` API for accurate PDF/image counting — worked for the decision but blew up the moment compression triggered:

```
TypeError: '>=' not supported between instances of 'coroutine' and 'int'
RuntimeWarning: coroutine '...' was never awaited
```

This was reachable in real usage via `ContextManagerCapability.before_model_request`, which delegates the compression to `SummarizationProcessor.__call__`.

## Fix

`__call__` (already `async`) now routes **both** counter invocations through the existing async helpers:

- `await async_count_tokens(self.token_counter, messages)` for the trigger total
- `await async_determine_cutoff_index(...)` for the cutoff (awaits the counter inside the binary search)

The synchronous helper methods/functions are left unchanged for sync counters — consistent with the "sync stays, async added alongside" approach already used in `_cutoff.py`.

## Tests

Added `TestAsyncTokenCounterCallPath` covering an async counter end-to-end through `__call__`:
- triggers summarization via an async counter,
- exercises the async **token-based** binary-search cutoff,
- returns history unchanged when under the trigger.

Verified with the exact reproduction from the issue — it now passes with no `TypeError`/`RuntimeWarning`.

## Checks

- `make test` — **237 passed, 100% coverage**
- `pyright` — 0 errors
- `mypy src` — clean
- `ruff check` / `ruff format --check` — clean

Version bumped `0.1.6 → 0.1.7`; changelog updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)