### PR TITLE
Don't stringify ToolReturn (binary) in after_tool_execute

### DIFF
--- a/src/pydantic_ai_summarization/capability.py
+++ b/src/pydantic_ai_summarization/capability.py
@@ -22,7 +22,7 @@ from typing import Any
 
 from pydantic_ai import RunContext
 from pydantic_ai.capabilities import AbstractCapability
-from pydantic_ai.messages import ModelMessage, ToolCallPart
+from pydantic_ai.messages import ModelMessage, ToolCallPart, ToolReturn
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.toolsets import FunctionToolset
 
@@ -60,19 +60,26 @@ def _resolve_max_tokens(model_id: str) -> int | None:  # pragma: no cover
     return None
 
 
-def _truncate_tool_output(text: str, head_lines: int, tail_lines: int) -> str:
-    """Truncate tool output keeping head and tail lines."""
+def _truncate_tool_output(
+    text: str, head_lines: int, tail_lines: int, max_chars: int | None = None
+) -> str:
+    """Truncate tool output keeping head and tail lines, bounded by max_chars."""
     lines = text.splitlines()
     total_lines = len(lines)
 
-    if total_lines <= head_lines + tail_lines:
-        return text
+    if total_lines > head_lines + tail_lines:
+        head = lines[:head_lines]
+        tail = lines[-tail_lines:]
+        omitted = total_lines - head_lines - tail_lines
+        return "\n".join([*head, f"\n... ({omitted} lines omitted) ...\n", *tail])
 
-    head = lines[:head_lines]
-    tail = lines[-tail_lines:]
-    omitted = total_lines - head_lines - tail_lines
+    # Few/no newlines to truncate by line: fall back to a character budget.
+    if max_chars is not None and len(text) > max_chars:
+        keep = max(1, max_chars // 2)
+        omitted = len(text) - 2 * keep
+        return f"{text[:keep]}\n... ({omitted} characters omitted) ...\n{text[-keep:]}"
 
-    return "\n".join([*head, f"\n... ({omitted} lines omitted) ...\n", *tail])
+    return text
 
 
 @dataclass
@@ -475,18 +482,36 @@ class ContextManagerCapability(AbstractCapability[Any]):
         args: dict[str, Any],
         result: Any,
     ) -> Any:
-        """Truncate large tool outputs."""
+        """Truncate large tool outputs.
+
+        Only plain ``str`` results and a ``ToolReturn``'s textual
+        ``return_value`` are truncated; a ``ToolReturn`` is never stringified,
+        since its ``content`` may carry ``BinaryContent`` that ``str()`` would
+        inline as a multi-MB blob.
+        """
         if self.max_tool_output_tokens is None:
             return result
 
-        result_str = str(result) if not isinstance(result, str) else result
         char_limit = self.max_tool_output_tokens * 4
 
-        if len(result_str) <= char_limit:
+        if isinstance(result, ToolReturn):
+            if isinstance(result.return_value, str) and len(result.return_value) > char_limit:
+                result.return_value = _truncate_tool_output(
+                    result.return_value,
+                    self.tool_output_head_lines,
+                    self.tool_output_tail_lines,
+                    max_chars=char_limit,
+                )
+            return result
+
+        if not isinstance(result, str) or len(result) <= char_limit:
             return result
 
         return _truncate_tool_output(
-            result_str, self.tool_output_head_lines, self.tool_output_tail_lines
+            result,
+            self.tool_output_head_lines,
+            self.tool_output_tail_lines,
+            max_chars=char_limit,
         )
 
 

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -6,7 +6,13 @@ from typing import Any
 
 import pytest
 from pydantic_ai import Agent, RunContext
-from pydantic_ai.messages import ModelRequest, ToolCallPart, UserPromptPart
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelRequest,
+    ToolCallPart,
+    ToolReturn,
+    UserPromptPart,
+)
 from pydantic_ai.models.test import TestModel
 from pydantic_ai.tools import ToolDefinition
 from pydantic_ai.usage import RunUsage
@@ -182,6 +188,46 @@ class TestContextManagerCapability:
         )
         assert result == large
 
+    @pytest.mark.anyio
+    async def test_tool_return_binary_not_stringified(self):
+        """A ToolReturn carrying BinaryContent must never be stringified."""
+        cap = ContextManagerCapability(max_tool_output_tokens=10)  # 40 chars
+        ctx = _make_ctx()
+        call = ToolCallPart(tool_name="read_file", args={}, tool_call_id="c1")
+        tool_def = ToolDefinition(name="read_file", description="read")
+
+        big_pdf = b"%PDF-1.4\n" + b"\x00" * 5_000_000
+        tr = ToolReturn(
+            return_value="Successfully read file: doc.pdf",
+            content=[
+                "Content of doc.pdf:",
+                BinaryContent(data=big_pdf, media_type="application/pdf"),
+            ],
+        )
+
+        result = await cap.after_tool_execute(ctx, call=call, tool_def=tool_def, args={}, result=tr)
+
+        assert isinstance(result, ToolReturn)
+        assert result.return_value == "Successfully read file: doc.pdf"
+        assert result.content is not None
+        binary = result.content[1]
+        assert isinstance(binary, BinaryContent)
+        assert len(binary.data) == len(big_pdf)
+
+    @pytest.mark.anyio
+    async def test_tool_return_long_text_return_value_truncated(self):
+        """A ToolReturn's large textual return_value is still truncated."""
+        cap = ContextManagerCapability(max_tool_output_tokens=10)  # 40 chars
+        ctx = _make_ctx()
+        call = ToolCallPart(tool_name="grep", args={}, tool_call_id="c1")
+        tool_def = ToolDefinition(name="grep", description="search")
+
+        tr = ToolReturn(return_value="\n".join(f"line {i}" for i in range(100)))
+        result = await cap.after_tool_execute(ctx, call=call, tool_def=tool_def, args={}, result=tr)
+        assert isinstance(result, ToolReturn)
+        assert "omitted" in str(result.return_value)
+        assert len(str(result.return_value)) < 200
+
 
 class TestTruncateToolOutput:
     def test_short_text_unchanged(self):
@@ -190,6 +236,14 @@ class TestTruncateToolOutput:
 
         result = _truncate_tool_output("line1\nline2\nline3", head_lines=5, tail_lines=5)
         assert result == "line1\nline2\nline3"
+
+    def test_single_long_line_truncated_by_chars(self):
+        """A huge single line (no newlines) is bounded by the char budget."""
+        from pydantic_ai_summarization.capability import _truncate_tool_output
+
+        result = _truncate_tool_output("x" * 100_000, head_lines=5, tail_lines=5, max_chars=1000)
+        assert "characters omitted" in result
+        assert len(result) < 1100
 
 
 class TestSerializationNames:

--- a/uv.lock
+++ b/uv.lock
@@ -1430,7 +1430,7 @@ wheels = [
 
 [[package]]
 name = "summarization-pydantic-ai"
-version = "0.2.0"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic-ai-slim" },


### PR DESCRIPTION
## Problem

`ContextManagerCapability.after_tool_execute` truncates large tool outputs by doing `str(result)` and then line-based truncation. For a `ToolReturn` whose `content` carries `BinaryContent` (e.g. a tool that returns a PDF/image/file), this is catastrophic:

1. `str(result)` inlines the entire binary as a multi-MB `repr` (a few-MB file becomes ~3-4 chars/byte of text).
2. `_truncate_tool_output` splits on newlines — a binary blob has none, so `total_lines <= head+tail` and it returns the **whole** string unchanged.

The giant string then lands on the `ToolReturnPart` and is sent to the provider, which rejects it (e.g. Gemini: `400 The input token count exceeds the maximum`). Small files stay under the char limit and pass through fine, so it only manifests with large binary tool results.

## Fix

- `after_tool_execute` no longer stringifies a `ToolReturn`. It only truncates plain `str` results and a `ToolReturn`'s textual `return_value`, leaving binary/structured `content` untouched.
- `_truncate_tool_output` gains an optional `max_chars` budget used as a fallback when there are too few newlines to truncate by line (a single huge JSON blob or base64 string), so output is always bounded.

## Tests

Added regression tests:
- a `ToolReturn` carrying multi-MB `BinaryContent` passes through with its binary intact (no stringification),
- a `ToolReturn`'s long textual `return_value` is still truncated,
- a single huge line (no newlines) is bounded by the char budget.

All existing tests pass.