### PR TITLE
fix: LimitWarnerProcessor drops already-empty trailing ModelRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`LimitWarnerProcessor` no longer drops an already-empty trailing `ModelRequest`.** `_strip_existing_warnings` removed any `ModelRequest` that ended up with no parts, but it also removed requests that were *already* empty before stripping. pydantic-ai appends an empty `ModelRequest` when resuming without a prompt (e.g. on a transient-error retry) so the history ends with a request; stripping it left the history ending on a `ModelResponse`, which trips pydantic-ai's `Processed history must end with a `ModelRequest`` validation (`UserError`). The processor now only drops a request when it actually removed injected warning parts, preserving structural placeholders and any non-warning parts.
+
 ## [0.1.9] - 2026-06-22
 
 ### Fixed

--- a/src/pydantic_ai_summarization/limit_warner.py
+++ b/src/pydantic_ai_summarization/limit_warner.py
@@ -157,12 +157,17 @@ class LimitWarnerProcessor:
                 continue
 
             parts = [part for part in message.parts if not self._is_limit_warning_part(part)]
-            if not parts:
-                continue
             if len(parts) == len(message.parts):
+                # No warning parts to strip. Keep the request untouched, including an
+                # already-empty `ModelRequest`: that is a structural placeholder (e.g. the
+                # trailing request pydantic-ai appends when resuming without a prompt) and
+                # must survive so the history still ends with a `ModelRequest`.
                 cleaned_messages.append(message)
-            else:
-                cleaned_messages.append(replace(message, parts=parts))  # pragma: no cover
+                continue
+            if not parts:
+                # The request held only warnings we injected; drop the whole turn.
+                continue
+            cleaned_messages.append(replace(message, parts=parts))
 
         return cleaned_messages
 

--- a/tests/test_limit_warner.py
+++ b/tests/test_limit_warner.py
@@ -334,6 +334,57 @@ class TestLimitWarnerProcessor:
         assert warning is not None
         assert "Iterations: 8/10" in warning
 
+    @pytest.mark.anyio
+    async def test_preserves_empty_trailing_request_when_resuming(self):
+        """Test an already-empty trailing ModelRequest is not stripped.
+
+        pydantic-ai appends an empty `ModelRequest` when resuming without a
+        prompt so the history ends with a request. Stripping it would leave the
+        history ending on a `ModelResponse`, which trips pydantic-ai's
+        'Processed history must end with a `ModelRequest`' validation.
+        """
+        processor = LimitWarnerProcessor(max_iterations=10)
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content="Earlier question")]),
+            ModelResponse(parts=[TextPart(content="Earlier answer")]),
+            ModelRequest(parts=[]),
+        ]
+        # Below threshold: no new warning is appended, so the only thing that
+        # could change the tail is the (buggy) stripping of the empty request.
+        ctx = _make_ctx(requests=1)
+
+        result = await processor(ctx, messages)
+
+        assert result == messages
+        assert isinstance(result[-1], ModelRequest)
+        assert result[-1].parts == []
+
+    @pytest.mark.anyio
+    async def test_strips_warning_part_but_keeps_real_parts_in_same_request(self):
+        """Test a request mixing a warning part and a real part keeps the real one."""
+        processor = LimitWarnerProcessor(max_iterations=10)
+        messages: list[ModelMessage] = [
+            ModelRequest(parts=[UserPromptPart(content="Earlier question")]),
+            ModelResponse(parts=[TextPart(content="Earlier answer")]),
+            ModelRequest(
+                parts=[
+                    UserPromptPart(content="Real question"),
+                    UserPromptPart(content=f"{_WARNING_MARKER}\nstale warning"),
+                ]
+            ),
+        ]
+        ctx = _make_ctx(requests=1)
+
+        result = await processor(ctx, messages)
+
+        assert _generated_warning_text(result) is None
+        trailing = result[-1]
+        assert isinstance(trailing, ModelRequest)
+        assert len(trailing.parts) == 1
+        remaining = trailing.parts[0]
+        assert isinstance(remaining, UserPromptPart)
+        assert remaining.content == "Real question"
+
     def test_factory_custom_token_counter(self):
         """Test factory forwards custom token_counter."""
 


### PR DESCRIPTION
## Summary

`LimitWarnerProcessor._strip_existing_warnings` removes any `ModelRequest` that ends up with no parts after warning-part removal. The problem: it also removes requests that were **already empty before stripping**.

pydantic-ai appends an empty `ModelRequest` when an agent run resumes **without a new prompt** (e.g. resuming accumulated history after a transient-error retry, via `agent.iter(message_history=..., user_prompt=None)`). That empty request exists precisely so the history ends with a `ModelRequest`, satisfying the validation in `_agent_graph._process_message_history`.

When this processor is in the `history_processors` chain, it strips that structural placeholder, leaving the processed history ending on a `ModelResponse`. pydantic-ai (since v1.0.8) then raises:

```
pydantic_ai.exceptions.UserError: Processed history must end with a `ModelRequest`.
```

### Before

```python
parts = [part for part in message.parts if not self._is_limit_warning_part(part)]
if not parts:          # fires for genuine warning-only turns AND already-empty requests
    continue
if len(parts) == len(message.parts):
    cleaned_messages.append(message)
else:
    cleaned_messages.append(replace(message, parts=parts))
```

### After

Only drop a request when injected warning parts were *actually* removed. If nothing was a warning (`len(parts) == len(message.parts)`), keep the message untouched — including an already-empty structural placeholder.

```python
parts = [part for part in message.parts if not self._is_limit_warning_part(part)]
if len(parts) == len(message.parts):
    cleaned_messages.append(message)  # keep, incl. empty structural request
    continue
if not parts:
    continue  # request held only injected warnings -> drop the whole turn
cleaned_messages.append(replace(message, parts=parts))
```

## Tests

- `test_preserves_empty_trailing_request_when_resuming` — empty trailing `ModelRequest` survives so history still ends with a request.
- `test_strips_warning_part_but_keeps_real_parts_in_same_request` — a request mixing a stale warning part and a real part keeps the real part (this also covers the previously `# pragma: no cover` mixed-parts branch with a real test).

## Checks

- `coverage run -m pytest` — 261 passed, **100% line + branch coverage** (`fail_under = 100`).
- `ruff format --check`, `ruff check`, `pyright`, `mypy` — all clean.

## Notes

This is reachable in normal multi-turn use too: pydantic-ai merges consecutive trailing `ModelRequest`s, so a previously-injected warning turn can end up merged with the real user turn, and the next strip pass must keep the real part — covered by the second test.

Made with [Cursor](https://cursor.com)